### PR TITLE
Correct default `TVFM_DIR` value for macOS

### DIFF
--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -2,7 +2,7 @@
 
 | Variable         | Secondary Variable | Meaning        | Default | 
 |------------------|--------------------|----------------|---------|
-| TFVM_DIR | n/a | tfvm inventory dir | ${HOME}/.tfvm on OS X and windows, ${HOME}/.cache/tfvm/ on Linux |
+| TFVM_DIR | n/a | tfvm inventory dir | ${HOME}/.tfvm on windows, ${HOME}/.cache/tfvm/ on Linux and macOS |
 | TFVM_TERRAFORM_VERSION | TERRAFORM_VERSION | Selected terraform version | |
 | TFVM_TERRAFORM_ARCH | TERRAFORM_ARCH | Arch of selected terraform version: amd64, 386 | Platform arch |
 | TFVM_TERRAFORM_OS | TERRAFORM_OS | OS of selected terraform version: windows, darwin, linux | Platform os |


### PR DESCRIPTION
I noticed that my cache files were in `~/.cache/tvfm` rather than in `~/.tvfm`, but I am not on Linux nor do I have `$XDG_CACHE_HOME` set. Strictly speaking, the macOS directory should probably be `~/Library/Caches/tvfm`, but `~/.cache/tvfm` is perfectly acceptable.

If the decision tree is more complex than that (e.g,. `~/.cache` exists, therefore use `~/.cache/tvfm`; if not, use `~/.tvfm`), then feel free to ignore this proposed update.

Also note that the "modern" name is _macOS_, not _Mac OS X_ or _OS X_. macOS now goes to 11. 😆 