### PR TITLE
Update gh action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Test
       run: go test ./internal/... ./cmd/...
@@ -25,7 +25,7 @@ jobs:
       if: runner.os == 'Linux'
 
     - name: Upload coverage data to codecov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.txt
       if: runner.os == 'Linux'

--- a/readme.md
+++ b/readme.md
@@ -46,12 +46,12 @@ tfvm list
 
 ### Configure terraform version
 ```
-echo "0.12.8" > .terraform-version
+echo "1.3.7" > .terraform-version
 
 tfvm which
 ```
 
-"latest" and [semver ranges](https://github.com/hashicorp/go-version#version-constraints), e.g. ```>= 0.12.1, <0.12.10```, are also supported.
+"latest" and [semver ranges](https://github.com/hashicorp/go-version#version-constraints), e.g. ```>= 1.3.0, <1.4.0```, are also supported.
 
 ### Invoke selected terraform
 ```


### PR DESCRIPTION
While doing #40, I came across the gh actions and some older dependencies. Here"s a PR for updating these to latest version.

Some notes:
- actions/setup-go@v2, actions/checkout@v2 are available in v3 and should not throw warnings regarding Node.js 12 anymore:
```shell
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/setup-go@v2, actions/checkout@v2
```
- codecov v1 will be [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1) by Feb 1 this year. So it has to move to v2 or v3. I don't know how codecov works and there are possible breaking changes, but so far it looks good to me. You should take a look at v3 before merging this PR.
- I noticed some older versions of terraform in the readme and kept them up to date as well ;)
